### PR TITLE
Improved template for Feather repository

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -220,16 +220,29 @@ generate_store_json "gbox.json" "$GBOX_JSON" "appRepositories" 'map({
 
 generate_store_json "feather.json" "$FEATHER_JSON" "apps" 'map({
   name: .displayName,
-  developerName: "dvntm",
   bundleIdentifier: .bundleIdentifier,
+  developerName: "dvntm",
   subtitle: .subtitle,
-  version: .version,
-  downloadURL: .downloadURL,
-  iconURL: .iconURL,
   localizedDescription: .description,
-  tintColor: (.tintColor | sub("^#"; "")),
-  size: .size,
-  screenshotURLs: .screenshots
+  iconURL: .iconURL,
+  tintColor: .tintColor,
+  screenshotURLs: .screenshots,
+  appPermissions: {
+    entitlements: .entitlements,
+    privacy: .privacy
+  },
+  versions: [
+    {
+    version: .version,
+    minOSVersion: .minOSVersion,
+    date: .date,
+    size: .size,
+    downloadURL: .downloadURL,
+    localizedDescription: .versionDescription
+    }
+  ],
+  version: .version,
+  size: .size
 })'
 
 generate_store_json "scarlet.json" "$SCARLET_JSON" "Tweaked" 'map({

--- a/scripts/template.json
+++ b/scripts/template.json
@@ -30,7 +30,7 @@
     {
       "title": "All my mods in one place",
       "identifier": "Dan-about",
-      "caption": "Welcome to the official AltStore repository of Dan's Workshop!\n\nHere, you can explore and download all of my free tweaked apps.",
+      "caption": "Welcome to the official Feather repository of Dan's Workshop!\n\nHere, you can explore and download all of my free tweaked apps.",
       "tintColor": "E36678",
       "imageURL": "https://raw.githubusercontent.com/dayanch96/YTLite/refs/heads/main/Resources/header.png",
       "url": "https://patreon.com/dayanch96",

--- a/scripts/template.json
+++ b/scripts/template.json
@@ -23,14 +23,21 @@
   "feather.json": {
     "name": "Dan's Workshop",
     "identifier": "com.dvntm.workshop",
+    "website": "https://patreon.com/dayanch96",
     "iconURL": "https://raw.githubusercontent.com/dayanch96/YTLite/refs/heads/main/Resources/icon.png",
-    "sourceURL": "https://github.com/dvntm0/AltStore/raw/refs/heads/main/sidestore.json",
-    "featuredApps": [
-      "com.google.ios.youtube",
-      "com.google.ios.youtubemusic",
-      "com.firecore.infuse"
-    ],
-    "apps": "{{apps}}"
+    "apps": "{{apps}}",
+    "news": [
+    {
+      "title": "All my mods in one place",
+      "identifier": "Dan-about",
+      "caption": "Welcome to the official AltStore repository of Dan's Workshop!\n\nHere, you can explore and download all of my free tweaked apps.",
+      "tintColor": "E36678",
+      "imageURL": "https://raw.githubusercontent.com/dayanch96/YTLite/refs/heads/main/Resources/header.png",
+      "url": "https://patreon.com/dayanch96",
+      "date": "2025-02-03",
+      "notify": true
+    }
+  ]
   },
   "esign.json": {
     "name": "Dan's Workshop",


### PR DESCRIPTION
Current template have missing structure. 
Add missing:
- Update date for apps
- info about versions
- Last update description (changelog)
- App permissions

Additional:
- Move repo description with link to News (before completly repo don't show it)

### Before: 
<img width="295" height="639" alt="IMG_7450" src="https://github.com/user-attachments/assets/2fc161e4-3048-4ca7-960f-0e60b858d6dd" /> <img width="295" height="639" alt="IMG_7449" src="https://github.com/user-attachments/assets/aba28247-de15-45ac-a56b-a38cda8dc9a4" />

### Current:
<img width="295" height="639" alt="IMG_7446" src="https://github.com/user-attachments/assets/3ec8e529-0dfe-4343-87dd-fed528beac3b" /> <img width="295" height="639" alt="IMG_7447" src="https://github.com/user-attachments/assets/0815b972-48f3-4372-8963-2d9a39814ea1" /> <img width="295" height="639" alt="IMG_7448" src="https://github.com/user-attachments/assets/d26a341d-9294-403f-a951-f5d76f171eb5" /> <img width="295" height="639" alt="IMG_7444" src="https://github.com/user-attachments/assets/6fa2b65c-512b-4f06-8237-b4e614eb8fad" /> <img width="295" height="639" alt="IMG_7445" src="https://github.com/user-attachments/assets/e3da4c7b-effd-4ca7-84a0-553bc391fe22" />
