### PR TITLE
Add info to news about subscription ytplus

### DIFF
--- a/feather.json
+++ b/feather.json
@@ -720,6 +720,16 @@
       "url": "https://patreon.com/dayanch96",
       "date": "2025-02-03",
       "notify": true
+    },
+    {
+      "title": "From version 5.2, YTPlus requires a subscription",
+      "identifier": "News1",
+      "caption": "Starting from version 5.2, YTPlus requires a Patreon subscription (activation in YTPlus settings).\n\nThis subscription applies strictly to YTPlus tweak features only and is not affiliated with YouTube or any other tweaks.\n\nThe last free version is 5.2b4.",
+      "tintColor": "E36678",
+      "imageURL": "https://raw.githubusercontent.com/marcinmajsc/YTLite/refs/heads/test/Resources/news1.png",
+      "url": "https://patreon.com/dayanch96",
+      "date": "2026-04-22",
+      "notify": true
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -463,5 +463,17 @@
         }
       ]
     }
+  ],
+  "news": [
+    {
+      "title": "From version 5.2, YTPlus requires a subscription",
+      "identifier": "News1",
+      "caption": "Starting from version 5.2, YTPlus requires a Patreon subscription (activation in YTPlus settings).\n\nThis subscription applies strictly to YTPlus tweak features only and is not affiliated with YouTube or any other tweaks.\n\nThe last free version is 5.2b4.",
+      "tintColor": "#E36678",
+      "imageURL": "https://raw.githubusercontent.com/marcinmajsc/YTLite/refs/heads/test/Resources/news1.png",
+      "url": "https://patreon.com/dayanch96",
+      "date": "2026-04-22",
+      "notify": true
+    }
   ]
 }

--- a/sidestore.json
+++ b/sidestore.json
@@ -231,5 +231,17 @@
         }
       ]
     }
+  ],
+  "news": [
+    {
+      "title": "From version 5.2, YTPlus requires a subscription",
+      "identifier": "News1",
+      "caption": "Starting from version 5.2, YTPlus requires a Patreon subscription (activation in YTPlus settings).\n\nThis subscription applies strictly to YTPlus tweak features only and is not affiliated with YouTube or any other tweaks.\n\nThe last free version is 5.2b4.",
+      "tintColor": "#E36678",
+      "imageURL": "https://raw.githubusercontent.com/marcinmajsc/YTLite/refs/heads/test/Resources/news1.png",
+      "url": "https://patreon.com/dayanch96",
+      "date": "2026-04-22",
+      "notify": true
+    }
   ]
 }


### PR DESCRIPTION
Proposition for feather.json, repo.json and sidestore.json
The content is just an example, and the graphic is in my YTPlus fork, so you’d still need to add your own changes 🙂

Final effect:

https://github.com/user-attachments/assets/b8f7752c-a6df-487f-bd94-d2b3f98289c0

https://github.com/user-attachments/assets/59ef2a16-442c-410e-be75-93733a34b3cc

